### PR TITLE
Add toggle to remove read-onlyness from etudes

### DIFF
--- a/ToyBox/classes/MainUI/Etudes/EtudesEditor.cs
+++ b/ToyBox/classes/MainUI/Etudes/EtudesEditor.cs
@@ -80,6 +80,8 @@ namespace ToyBox {
                 25.space();
                 Toggle("Show GUIDs".localize(), ref Main.Settings.showAssetIDs);
                 25.space();
+                Toggle("Allow to start read-only etudes".localize(), ref Main.Settings.allEtudesReadable);
+                25.space();
                 Toggle("Show Comments (some in Russian)".localize(), ref Main.Settings.showEtudeComments);
                 //UI.Label($"Etude Hierarchy : {(loadedEtudes.Count == 0 ? "" : loadedEtudes[parent].Name)}", UI.AutoWidth());
                 //UI.Label($"H : {(loadedEtudes.Count == 0 ? "" : loadedEtudes[selected].Name)}");

--- a/ToyBox/classes/Models/Settings.cs
+++ b/ToyBox/classes/Models/Settings.cs
@@ -224,6 +224,7 @@ namespace ToyBox {
         public bool toggleDisableCorruption = false;
         public float enduringSpellsTimeThreshold = 60f;
         public float greaterEnduringSpellsTimeThreshold = 5f;
+        public bool allEtudesReadable = false;
 
         // Loot 
         public bool toggleColorLootByRarity = false;

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Tweaks.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Tweaks.cs
@@ -1,5 +1,7 @@
 ﻿using HarmonyLib;
 using Kingmaker.View.MapObjects.Traps;
+using Kingmaker.AreaLogic.Etudes;
+using System;
 
 namespace ToyBox.BagOfPatches {
     internal static partial class Tweaks {
@@ -7,6 +9,17 @@ namespace ToyBox.BagOfPatches {
         public static class TrapObjectData_TryTriggerTrap_Patch {
             private static bool Prefix() {
                 if (Settings.disableTraps) {
+                    return false;
+                }
+                return true;
+            }
+        }
+
+        [HarmonyPatch(typeof(BlueprintEtude), nameof(BlueprintEtude.IsReadOnly), MethodType.Getter)]
+        public static class BlueprintEtude_IsReadOnly_Patch {
+            private static bool Prefix(ref bool __result) {
+                if (Settings.allEtudesReadable) {
+                    __result = false;
                     return false;
                 }
                 return true;


### PR DESCRIPTION
One use I know for it - InevitableDarkness_KilledOn* etudes are read-only in the main campaign, this toggle allows to start them anyway which allows to get the benefits of those without having to re-do Inevitable Excess with the feat.