### PR TITLE
Fix Merging Manually Added Mythic Spell Books

### DIFF
--- a/ToyBox/classes/Infrastructure/CasterHelpers.cs
+++ b/ToyBox/classes/Infrastructure/CasterHelpers.cs
@@ -1,4 +1,4 @@
-﻿using Kingmaker.Blueprints;
+using Kingmaker.Blueprints;
 using Kingmaker.Blueprints.Classes;
 using Kingmaker.Blueprints.Root;
 using Kingmaker.EntitySystem.Entities;
@@ -246,25 +246,29 @@ namespace ToyBox.classes.Infrastructure {
         }
 #endif
 
-        public static IEnumerable<ClassData> MergableClasses(this UnitEntityData unit) {
+        public static IEnumerable<BlueprintSpellbook> MergableClasses(this UnitEntityData unit) {
             var spellbookCandidates = unit.Spellbooks
                                           .Where(sb => sb.IsStandaloneMythic && sb.Blueprint.CharacterClass != null)
                                           .Select(sb => sb.Blueprint).ToHashSet();
+            /* Dragon's comment on this. Why are we looking for the Mythic class here? It means you can't merge mythic spellbooks that are added via Toybox
+             * Or any other method that wouldn't add the Mythic class
+             * Looks like maybe for localized name, but... then it's not that functional
+             */
             //Mod.Log($"{unit.CharacterName} - spellbookCandidates: {string.Join(", ", spellbookCandidates.Select(sb => sb.DisplayName))}");
-            var classCandidates = unit.Progression.Classes
-                                      .Where(cl => cl.Spellbook != null && spellbookCandidates.Contains(cl.Spellbook));
+            //var classCandidates = unit.Progression.Classes
+            //                          .Where(cl => cl.Spellbook != null && spellbookCandidates.Contains(cl.Spellbook));
             //Mod.Log($"{unit.CharacterName} - classCandidates: {string.Join(", ", classCandidates.Select(cl => cl.CharacterClass.Name))}");
-            return classCandidates;
+            return spellbookCandidates;
         }
-        public static void MergeMythicSpellbook(this Spellbook targetSpellbook, ClassData fromClass) {
+        public static void MergeMythicSpellbook(this Spellbook targetSpellbook, BlueprintSpellbook fromClass) {
             var unit = targetSpellbook.Owner;
-            var oldMythicSpellbookBp = fromClass?.Spellbook;
+            var oldMythicSpellbookBp = fromClass;
             if (fromClass == null || oldMythicSpellbookBp == null || !oldMythicSpellbookBp.IsMythic) {
                 Mod.Warn("Can't merge because you don't have a mythic class / mythic spellbook!");
                 return;
             }
 
-            fromClass.Spellbook = targetSpellbook.Blueprint;
+            //fromClass.Spellbook = targetSpellbook.Blueprint;
             targetSpellbook.m_Type = SpellbookType.Mythic;
             targetSpellbook.AddSpecialList(oldMythicSpellbookBp.MythicSpellList);
             for (var i = targetSpellbook.MythicLevel; i < unit.Progression.MythicLevel; i++) {

--- a/ToyBox/classes/MainUI/PartyEditor/SpellsEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor/SpellsEditor.cs
@@ -1,4 +1,4 @@
-﻿using Kingmaker.Blueprints;
+using Kingmaker.Blueprints;
 using Kingmaker.EntitySystem.Entities;
 using Kingmaker.UnitLogic;
 using Kingmaker.UnitLogic.Abilities;
@@ -45,7 +45,7 @@ namespace ToyBox {
                         25.space();
                         foreach (var cl in mergeableClasses) {
                             var sb = spellbook;
-                            ActionButton(cl.CharacterClass.LocalizedName.ToString(), () => sb.MergeMythicSpellbook(cl));
+                            ActionButton(cl.GetDisplayName(), () => sb.MergeMythicSpellbook(cl));
                             15.space();
                         }
                         25.space();


### PR DESCRIPTION
From a conversation [in Discord](https://discord.com/channels/645948717400064030/815735034514112512/1254705585023090688), it appears that if you add a Mythic spell book via the Party tab, you are unable to merge it with the current implementation

These changes shouldTM fix that, but I am unsure of whether or not there will be edge cases with this.

In addition, I don't believe I grab the localized name for the mythic spell book with these changes, but I don't think there's a way to do it from the spell book BP? Granted, I'm on 4 hours of sleep so....

I did test with the conditions from the person on Discord (Oracle and a Toybox added Angel spellbook) and it worked in that test