### PR TITLE
Fix: Full Heal After Combat now includes Pets

### DIFF
--- a/ToyBox/Classes/MonkeyPatchin/BagOfPatches/TweaksWrath.cs
+++ b/ToyBox/Classes/MonkeyPatchin/BagOfPatches/TweaksWrath.cs
@@ -261,7 +261,7 @@ namespace ToyBox.BagOfPatches {
                     CheatsCombat.RestAll();
                 }
                 if (!inCombat && Settings.toggleFullHealAfterCombat) {
-                    foreach (var unit in Game.Instance.Player.Party) {
+                    foreach (var unit in Game.Instance.Player.PartyAndPets) {
                         Rulebook.Trigger(new RuleHealDamage(unit, unit, default, unit.Descriptor.Stats.HitPoints.ModifiedValue));
                         foreach (var attribute in unit.Stats.Attributes) {
                             attribute.Damage = 0;


### PR DESCRIPTION
## Description
Updated the "Full Heal After Combat" logic to include animal companions. 

Previously, this feature used `Game.Instance.Player.Party`, which excluded pets. Switched to `Game.Instance.Player.PartyAndPets` to ensure the entire active group is healed and restored after an encounter.