### PR TITLE
Feature: Add optional resurrection to Full Heal After Combat

### DIFF
--- a/ToyBox/Classes/MainUI/BagOfTricks.cs
+++ b/ToyBox/Classes/MainUI/BagOfTricks.cs
@@ -623,6 +623,12 @@ namespace ToyBox {
                 //() => UI.Toggle("Show Pet Portraits", ref settings.toggleShowAllPartyPortraits,0),
                 () => Toggle("Instant Rest After Combat".localize(), ref Settings.toggleInstantRestAfterCombat),
                 () => Toggle("Full Heal After Combat".localize(), ref Settings.toggleFullHealAfterCombat),
+                () => {
+                    if (Settings.toggleFullHealAfterCombat) {
+                        Space(25);
+                        Toggle("Also ressurect".localize(), ref Settings.toggleResurrectAfterCombat);
+                    }
+                },
                 () => Toggle("Instant change party members".localize(), ref Settings.toggleInstantChangeParty),
                 () => ToggleCallback("Equipment No Weight".localize(), ref Settings.toggleEquipmentNoWeight, BagOfPatches.Tweaks.NoWeight_Patch1.Refresh),
                 () => Toggle("Allow Equipment Change During Combat".localize(), ref Settings.toggleEquipItemsDuringCombat),

--- a/ToyBox/Classes/MainUI/BagOfTricks.cs
+++ b/ToyBox/Classes/MainUI/BagOfTricks.cs
@@ -626,7 +626,7 @@ namespace ToyBox {
                 () => {
                     if (Settings.toggleFullHealAfterCombat) {
                         Space(25);
-                        Toggle("Also ressurect".localize(), ref Settings.toggleResurrectAfterCombat);
+                        Toggle("Also resurrect".localize(), ref Settings.toggleResurrectAfterCombat);
                     }
                 },
                 () => Toggle("Instant change party members".localize(), ref Settings.toggleInstantChangeParty),

--- a/ToyBox/Classes/Models/Settings.cs
+++ b/ToyBox/Classes/Models/Settings.cs
@@ -221,6 +221,7 @@ namespace ToyBox {
         public bool toggleRechargeItemsAfterCombat = false;
         public bool toggleInstantRestAfterCombat = false;
         public bool toggleFullHealAfterCombat = false;
+        public bool toggleResurrectAfterCombat = false;
         public bool toggleShowAllPartyPortraits = false;    // TODO - port this
         public bool toggleAccessRemoteCharacters = false;
         public bool toggleInfiniteItems = false;

--- a/ToyBox/Classes/MonkeyPatchin/BagOfPatches/TweaksWrath.cs
+++ b/ToyBox/Classes/MonkeyPatchin/BagOfPatches/TweaksWrath.cs
@@ -262,6 +262,10 @@ namespace ToyBox.BagOfPatches {
                 }
                 if (!inCombat && Settings.toggleFullHealAfterCombat) {
                     foreach (var unit in Game.Instance.Player.PartyAndPets) {
+                        if (Settings.toggleResurrectAfterCombat && unit.Descriptor.State.IsFinallyDead) {
+                            unit.Descriptor.Resurrect(unit, 1, true);
+                            unit.Position = Game.Instance.Player.MainCharacter.Value.Position;
+                        }
                         Rulebook.Trigger(new RuleHealDamage(unit, unit, default, unit.Descriptor.Stats.HitPoints.ModifiedValue));
                         foreach (var attribute in unit.Stats.Attributes) {
                             attribute.Damage = 0;

--- a/ToyBox/Localization/en.json
+++ b/ToyBox/Localization/en.json
@@ -500,6 +500,7 @@
     "Instant Global Crusade Spells Cooldown": "Instant Global Crusade Spells Cooldown",
     "Instant Rest After Combat": "Instant Rest After Combat",
     "Full Heal After Combat": "Full Heal After Combat",
+    "Also ressurect": "Also ressurect",
     "Intelligence": "Intelligence",
     "Interesting NPCs in the local area": "Interesting NPCs in the local area",
     "Internal Name": "Internal Name",

--- a/ToyBox/Localization/en.json
+++ b/ToyBox/Localization/en.json
@@ -500,7 +500,7 @@
     "Instant Global Crusade Spells Cooldown": "Instant Global Crusade Spells Cooldown",
     "Instant Rest After Combat": "Instant Rest After Combat",
     "Full Heal After Combat": "Full Heal After Combat",
-    "Also ressurect": "Also ressurect",
+    "Also resurrect": "Also resurrect",
     "Intelligence": "Intelligence",
     "Interesting NPCs in the local area": "Interesting NPCs in the local area",
     "Internal Name": "Internal Name",


### PR DESCRIPTION
## Description
Expanded "Full Heal After Combat" to optionally include resurrection for party members and pets.

## Key Changes
* **New Sub-option:** Added "Also resurrect" toggle under the Full Heal setting.
* **Reliable Resurrection:** Uses `Resurrect(unit, 1, true)` paired with an `IsFinallyDead` check. Testing showed the parameterless `Resurrect()` was unreliable for this specific post-combat trigger.
* **Position Sync:** Teleports resurrected units to the Main Character to prevent them from getting stuck in combat geometry.

## Tested
Confirmed pets and heroes resurrect, heal to full, and teleport to the player correctly after combat.